### PR TITLE
Added a check to prevent creation of duplicate emails

### DIFF
--- a/server/src/features/users/UserRepository.ts
+++ b/server/src/features/users/UserRepository.ts
@@ -18,12 +18,6 @@ const repoErr: IRepoError = {
   statusCode: 500,
 };
 
-const dupeErr: IRepoError = {
-  location: 'UserRepository.js',
-  statusCode: 409,
-  message: 'A user with that email already exists',
-};
-
 const standardError = (message: string) => {
   repoErr.message = message;
   logger.warn(repoErr);
@@ -32,16 +26,6 @@ const standardError = (message: string) => {
 export default class UserRepository {
   public static async Add(user): Promise<IUser> {
     try {
-      const duplicate: IUser = await db.User.findOne({
-        where: {
-          email: user.email,
-          deleted: false,
-        },
-      });
-      if (duplicate != null) {
-        return Promise.reject(dupeErr);
-      }
-
       return await db.User.create(user);
     } catch (err) {
       standardError(`${err.name} ${err.message}`);

--- a/server/src/features/users/UserRepository.ts
+++ b/server/src/features/users/UserRepository.ts
@@ -20,7 +20,7 @@ const repoErr: IRepoError = {
 
 const dupeErr: IRepoError = {
   location: 'UserRepository.js',
-  statusCode: 422,
+  statusCode: 409,
   message: 'A user with that email already exists',
 };
 

--- a/server/src/features/users/UserRepository.ts
+++ b/server/src/features/users/UserRepository.ts
@@ -18,6 +18,12 @@ const repoErr: IRepoError = {
   statusCode: 500,
 };
 
+const dupeErr: IRepoError = {
+  location: 'UserRepository.js',
+  statusCode: 422,
+  message: 'A user with that email already exists',
+};
+
 const standardError = (message: string) => {
   repoErr.message = message;
   logger.warn(repoErr);
@@ -26,6 +32,16 @@ const standardError = (message: string) => {
 export default class UserRepository {
   public static async Add(user): Promise<IUser> {
     try {
+      const duplicate: IUser = await db.User.findOne({
+        where: {
+          email: user.email,
+          deleted: false,
+        },
+      });
+      if (duplicate != null) {
+        return Promise.reject(dupeErr);
+      }
+
       return await db.User.create(user);
     } catch (err) {
       standardError(`${err.name} ${err.message}`);

--- a/server/src/models/User.ts
+++ b/server/src/models/User.ts
@@ -71,6 +71,7 @@ export = (sequelize: any, DataTypes: any) => {
     email: {
       type: DataTypes.STRING,
       allowNull: false,
+      unique: true,
     },
     firstName: {
       type: DataTypes.STRING,


### PR DESCRIPTION
### Summary:
The purpose of this pull request is to add a check against a user creation
request that prevents the creation of duplicate users. this is done by checking
the database for any entries in the user table with the same email and that
aren't marked deleted.

### Other changes:
none

### Alternatives:
The check could possibly be moved to be implemented in an alternative location.
Currently it is located in UserRepository.js as it already imports the database.
The downside of this is that "POST user" gets logged despite a user not actually
being successfully created. The duplicate email error also returns code 422
(Unprocessable Entity) which I am not sure is the most fitting error code.

### Notes:
This is a relatively minor change but important as the login process only checks
the first user which matches an e-mail. If a user unknowingly registers with an
already in-use email they will be unable to login with their own password or end
up logging into another users account.