### PR TITLE
Database reconnect

### DIFF
--- a/server/.eslintrc.json
+++ b/server/.eslintrc.json
@@ -40,8 +40,6 @@
 
         "dot-notation": "off",
 
-        "no-underscore-dangle": "off",
-
-        "linebreak-style": 0
+        "no-underscore-dangle": "off"
     }
 }

--- a/server/.eslintrc.json
+++ b/server/.eslintrc.json
@@ -40,6 +40,8 @@
 
         "dot-notation": "off",
 
-        "no-underscore-dangle": "off"
+        "no-underscore-dangle": "off",
+
+        "linebreak-style": 0
     }
 }

--- a/server/src/Routes.ts
+++ b/server/src/Routes.ts
@@ -1,5 +1,6 @@
 import express from 'express';
 import userRouter from './features/users/UserRoute';
+import databaseHealth from './middleware/DatabaseHealth';
 
 const router = express.Router();
 
@@ -7,6 +8,7 @@ const router = express.Router();
 // ROUTES                                                                                          //
 // =============================================================================================== //
 
-router.use('/users', userRouter);
+router.use('/users', databaseHealth, userRouter);
+router.use('/check', (req, res) => res.json('OK'));
 
 export = router;

--- a/server/src/Server.ts
+++ b/server/src/Server.ts
@@ -5,13 +5,13 @@ import * as cookieParser from 'cookie-parser';
 import https from 'https';
 import passport from 'passport';
 import upload from 'express-fileupload';
+import * as databasePing from './utils/DatabasePing';
 import config from './config/index';
-import db from './models';
 import logger from './utils/Logger';
 import router from './Routes';
 import UserController from './features/users/UserController';
 
-const DB_PARAMS = config.db;
+const ping = databasePing.default;
 
 export default class Server {
     private app: Express;
@@ -38,21 +38,11 @@ export default class Server {
       // =============================================================================================== //
 
       // Verify database connection and sync if we wish
-      try {
-        await db.sequelize.authenticate();
-        if (DB_PARAMS.SYNC) {
-          await db.sequelize.sync(); // If this is enabled in config.json it will sync the DB to the code
-          // Create default user types if there are none
-          const userTypes = await db.UserType.findAll({});
-          if (userTypes.length === 0) {
-            await db.UserType.create({ value: 'Admin' });
-            await db.UserType.create({ value: 'User' });
-          }
+      ping.getPromise().then((online) => {
+        if (!online) {
+          logger.warn('Database not found, will attempt to reconnect on next db reliant request');
         }
-      } catch (e) {
-        logger.error(`Database configuration failed due to: ${e.message}`);
-        onServerClosed();
-      }
+      });
 
       // =============================================================================================== //
       //  MIDDLEWARE                                                                                     //

--- a/server/src/middleware/DatabaseHealth.ts
+++ b/server/src/middleware/DatabaseHealth.ts
@@ -4,7 +4,7 @@ const ping = databasePing.default;
 
 const databaseHealth = async (req, res, next) => {
   // if the server thinks it's already connected, confirm the response is good, and then send it through.
-  if (ping.databaseConnected) { 
+  if (ping.databaseConnected) {
     const { end } = res;
 
     res.end = function (a, b) { // This checks the status code of the response, to check if a disconnect has occured.
@@ -24,7 +24,7 @@ const databaseHealth = async (req, res, next) => {
     return res.status(500).json('Database could not be found. Please try again later.');
   }
   // If the database isnt connected, ping it to try and connect!
-  return ping.getPromise().then((online) => { 
+  return ping.getPromise().then((online) => {
     if (online) { // Connection was successful, but lets check to make sure
       const { end } = res;
 

--- a/server/src/middleware/DatabaseHealth.ts
+++ b/server/src/middleware/DatabaseHealth.ts
@@ -1,0 +1,33 @@
+import * as databasePing from '../utils/DatabasePing';
+
+const ping = databasePing.default;
+
+const databaseHealth = async (req, res, next) => {
+  if (ping.databaseConnected) {
+    try {
+      return next();
+    } catch {
+      ping.databaseConnected = false;
+      return res.status(500).json('Database could not be found. Please try again later.');
+    }
+  } else {
+    return ping.getPromise().then((online) => {
+      if (online) {
+        try {
+          return next();
+        } catch {
+          ping.databaseConnected = false;
+          return res.status(500).json('Database could not be found. Please try again later.');
+        }
+      }
+
+      ping.databaseConnected = false;
+      return res.status(500).json('Database could not be found. Please try again later.');
+    }).catch(() => {
+      ping.databaseConnected = false;
+      return res.status(500).json('Database could not be found. Please try again later.');
+    });
+  }
+};
+
+export default databaseHealth;

--- a/server/src/middleware/DatabaseHealth.ts
+++ b/server/src/middleware/DatabaseHealth.ts
@@ -3,10 +3,11 @@ import * as databasePing from '../utils/DatabasePing';
 const ping = databasePing.default;
 
 const databaseHealth = async (req, res, next) => {
-  if (ping.databaseConnected) {
+  // if the server thinks it's already connected, confirm the response is good, and then send it through.
+  if (ping.databaseConnected) { 
     const { end } = res;
 
-    res.end = function (a, b) {
+    res.end = function (a, b) { // This checks the status code of the response, to check if a disconnect has occured.
       if (res.statusCode >= 500) {
         ping.databaseConnected = false;
       }
@@ -15,18 +16,19 @@ const databaseHealth = async (req, res, next) => {
       res.end(a, b);
     };
 
-    if (ping.databaseConnected) {
+    if (ping.databaseConnected) { // connected and good to go
       return next();
     }
 
-    ping.databaseConnected = false;
+    ping.databaseConnected = false; // not actually connected, send an error!
     return res.status(500).json('Database could not be found. Please try again later.');
   }
-  return ping.getPromise().then((online) => {
-    if (online) {
+  // If the database isnt connected, ping it to try and connect!
+  return ping.getPromise().then((online) => { 
+    if (online) { // Connection was successful, but lets check to make sure
       const { end } = res;
 
-      res.end = function (a, b) {
+      res.end = function (a, b) { // This checks the status code of the response, to check if a disconnect has occured.
         if (res.statusCode >= 500) {
           ping.databaseConnected = false;
         }
@@ -35,18 +37,18 @@ const databaseHealth = async (req, res, next) => {
         res.end(a, b);
       };
 
-      if (ping.databaseConnected) {
+      if (ping.databaseConnected) { // connected and good to go
         return next();
       }
 
-      ping.databaseConnected = false;
+      ping.databaseConnected = false; // not actually successful, send an error!
       return res.status(500).json('Database could not be found. Please try again later.');
     }
 
-    ping.databaseConnected = false;
+    ping.databaseConnected = false; // (re)connect not successful, send an error!
     return res.status(500).json('Database could not be found. Please try again later.');
   }).catch(() => {
-    ping.databaseConnected = false;
+    ping.databaseConnected = false; // something went wrong trying to check for connection, send an error!
     return res.status(500).json('Database could not be found. Please try again later.');
   });
 };

--- a/server/src/middleware/DatabaseHealth.ts
+++ b/server/src/middleware/DatabaseHealth.ts
@@ -4,30 +4,51 @@ const ping = databasePing.default;
 
 const databaseHealth = async (req, res, next) => {
   if (ping.databaseConnected) {
-    try {
+    const { end } = res;
+
+    res.end = function (a, b) {
+      if (res.statusCode >= 500) {
+        ping.databaseConnected = false;
+      }
+
+      res.end = end;
+      res.end(a, b);
+    };
+
+    if (ping.databaseConnected) {
       return next();
-    } catch {
-      ping.databaseConnected = false;
-      return res.status(500).json('Database could not be found. Please try again later.');
     }
-  } else {
-    return ping.getPromise().then((online) => {
-      if (online) {
-        try {
-          return next();
-        } catch {
+
+    ping.databaseConnected = false;
+    return res.status(500).json('Database could not be found. Please try again later.');
+  }
+  return ping.getPromise().then((online) => {
+    if (online) {
+      const { end } = res;
+
+      res.end = function (a, b) {
+        if (res.statusCode >= 500) {
           ping.databaseConnected = false;
-          return res.status(500).json('Database could not be found. Please try again later.');
         }
+
+        res.end = end;
+        res.end(a, b);
+      };
+
+      if (ping.databaseConnected) {
+        return next();
       }
 
       ping.databaseConnected = false;
       return res.status(500).json('Database could not be found. Please try again later.');
-    }).catch(() => {
-      ping.databaseConnected = false;
-      return res.status(500).json('Database could not be found. Please try again later.');
-    });
-  }
+    }
+
+    ping.databaseConnected = false;
+    return res.status(500).json('Database could not be found. Please try again later.');
+  }).catch(() => {
+    ping.databaseConnected = false;
+    return res.status(500).json('Database could not be found. Please try again later.');
+  });
 };
 
 export default databaseHealth;

--- a/server/src/utils/DatabasePing.ts
+++ b/server/src/utils/DatabasePing.ts
@@ -7,7 +7,8 @@ const DB_PARAMS = config.db;
 export default class DatabasePing {
   static instance;
 
-  static databaseConnected = false;
+  /// if the server thinks the database is connected or not
+  static databaseConnected = false; 
 
   static isSearching;
 
@@ -16,7 +17,7 @@ export default class DatabasePing {
   static attemptConnect = async () : Promise<boolean> => {
     DatabasePing.isSearching = true;
 
-    try {
+    try { // attempt to connect to and set up the database
       await db.sequelize.authenticate();
       if (DB_PARAMS.SYNC) {
         await db.sequelize.sync(); // If this is enabled in config.json it will sync the DB to the code
@@ -30,7 +31,7 @@ export default class DatabasePing {
         DatabasePing.databaseConnected = true;
         logger.info('Database connected!');
       }
-    } catch (e) {
+    } catch (e) { // connection or setup failed, we are not connected to the database!
       logger.warn(`Database configuration failed due to: ${e.message}`);
       DatabasePing.databaseConnected = false;
     }
@@ -39,14 +40,14 @@ export default class DatabasePing {
     return DatabasePing.databaseConnected;
   }
 
-  static getInstance() : DatabasePing {
+  static getInstance() : DatabasePing { // singleton instance getter
     if (!DatabasePing.instance) {
       DatabasePing.instance = new DatabasePing();
     }
     return DatabasePing.instance;
   }
 
-  static getPromise() : Promise<boolean> {
+  static getPromise() : Promise<boolean> { // gets a promise to return if the DB is connected or not
     if (DatabasePing.isSearching) {
       return DatabasePing.promise;
     }

--- a/server/src/utils/DatabasePing.ts
+++ b/server/src/utils/DatabasePing.ts
@@ -8,7 +8,7 @@ export default class DatabasePing {
   static instance;
 
   /// if the server thinks the database is connected or not
-  static databaseConnected = false; 
+  static databaseConnected = false;
 
   static isSearching;
 

--- a/server/src/utils/DatabasePing.ts
+++ b/server/src/utils/DatabasePing.ts
@@ -1,0 +1,57 @@
+import config from '../config/index';
+import db from '../models';
+import logger from './Logger';
+
+const DB_PARAMS = config.db;
+
+export default class DatabasePing {
+  static instance;
+
+  static databaseConnected = false;
+
+  static isSearching;
+
+  static promise : Promise<boolean>;
+
+  static attemptConnect = async () : Promise<boolean> => {
+    DatabasePing.isSearching = true;
+
+    try {
+      await db.sequelize.authenticate();
+      if (DB_PARAMS.SYNC) {
+        await db.sequelize.sync(); // If this is enabled in config.json it will sync the DB to the code
+        // Create default user types if there are none
+        const userTypes = await db.UserType.findAll({});
+        if (userTypes.length === 0) {
+          await db.UserType.create({ value: 'Admin' });
+          await db.UserType.create({ value: 'User' });
+        }
+
+        DatabasePing.databaseConnected = true;
+        logger.info('Database connected!');
+      }
+    } catch (e) {
+      logger.warn(`Database configuration failed due to: ${e.message}`);
+      DatabasePing.databaseConnected = false;
+    }
+
+    DatabasePing.isSearching = false;
+    return DatabasePing.databaseConnected;
+  }
+
+  static getInstance() : DatabasePing {
+    if (!DatabasePing.instance) {
+      DatabasePing.instance = new DatabasePing();
+    }
+    return DatabasePing.instance;
+  }
+
+  static getPromise() : Promise<boolean> {
+    if (DatabasePing.isSearching) {
+      return DatabasePing.promise;
+    }
+
+    DatabasePing.promise = DatabasePing.attemptConnect();
+    return DatabasePing.promise;
+  }
+}


### PR DESCRIPTION
### Summary:
The purpose of this pull request is to enable the express-seed project to handle being disconnected from the
postgres database gracefully, and to be able to attempt to reconnect afterwards instead of crashing. It does
so via the implementation of a database ping utility, which attempts to connect to and set up the database
(which was done in server.ts previously) and stores a flag signaling if the database is connected or not, along with
a database health middleware, which can be added to any route to inform the program that requests through
the route need database connectivity, and should attempt to connect if it is disconnected.



### Other changes:
-A hearbeat route (express-server/api/v1/check) has been added to check if the server is running at all, regardless
of database connectivity.



### Usage:
To add the database check to any route, add the following import to your route file:
```import databaseHealth from './middleware/DatabaseHealth';```

then add ```databaseHealth``` as middleware to all appropriate routes.



### Notes:
The first request after a disconnect will return the generic connection error message for the database instead of
the more friendly one that normally is returned in the middleware.

