### PR TITLE
Added try/catch block to catch errors with HTTPS listener creation

### DIFF
--- a/server/src/Server.ts
+++ b/server/src/Server.ts
@@ -149,11 +149,15 @@ export default class Server {
           cert,
         };
 
-        https.createServer(options, this.app).listen(config.app.PORT_SECURE, () => {
-          logger.info(
-            `********************* HTTPS Server Listening on Port:${config.app.PORT_SECURE} *********************`,
-          );
-        });
+        try {
+          https.createServer(options, this.app).listen(config.app.PORT_SECURE, () => {
+            logger.info(
+              `********************* HTTPS Server Listening on Port:${config.app.PORT_SECURE} *********************`,
+            );
+          });
+        } catch {
+          logger.warn('Could not set up HTTPS listener, is your certificate valid?');
+        }
 
         this.app.listen(config.app.PORT, () => {
           logger.info(


### PR DESCRIPTION
### Summary
This is a simple PR which adds a try/catch block around the HTTPS listener creation. This allows the server to start up even if it cant create an HTTPS listener and logs an appropriate error when such an event happens.